### PR TITLE
docs: Fix for `nuxt.config` snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add `@nuxtjs/web-vitals` to the `buildModules` section of your `nuxt.config.js`
 export default {
   buildModules: [
     '@nuxtjs/web-vitals'
-  }
+  ]
 }
 ```
 


### PR DESCRIPTION
I just noticed a slight typo on the README file where the closing brace on the `buildModules` should have been an square bracket rather than a brace.

Great work from the Nuxt team on another fantastic module 😄 