### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@ This module will gather those metrics on each page view, and send them to a prov
 ## Installation
 
 ```bash
-# yarn
-yarn add --dev @nuxtjs/web-vitals
-
-# npm
-npm install --save-dev @nuxtjs/web-vitals
+npx nuxi@latest module add web-vitals
 ```
 
 Add `@nuxtjs/web-vitals` to the `modules` section of your `nuxt.config.js`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
